### PR TITLE
Fix readme bullet order

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,15 +5,15 @@ Read me in other languages: [日本語](README.md)
 ## Setup
 
 1. Install [Git](https://git-scm.com/), [Git LFS](https://git-lfs.github.com/), [RubyGems](https://rubygems.org/), [Jekyll](https://jekyllrb.com/), and [Bundler](http://bundler.io/)
-1. On terminal, run:
+2. On terminal, run:
 ```
 git clone https://github.com/nourished-jp/nourished-jp.github.io nourished
 cd nourished
 bundle install
 bundle exec jekyll serve
 ```
-1. Open browser and type in: ``http://127.0.0.1:4000``
-1. Start editing source. Check out [Jekyll docs](https://jekyllrb.com/docs/home/) for more info
+3. Open browser and type in: ``http://127.0.0.1:4000``
+4. Start editing source. Check out [Jekyll docs](https://jekyllrb.com/docs/home/) for more info
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 ## セットアップ
 
 1. [Git](https://git-scm.com/)、[Git LFS](https://git-lfs.github.com/)、[RubyGems](https://rubygems.org/)、[Jekyll](https://jekyllrb.com/)、[Bundler](http://bundler.io/)をインストールする
-1. ターミナルで以下のコマンドを入力:
+2. ターミナルで以下のコマンドを入力:
 ```
 git clone https://github.com/nourished-jp/nourished-jp.github.io nourished
 cd nourished
 bundle install
 bundle exec jekyll serve
 ```
-1. ブラウザで``http://127.0.0.1:4000``を開く
-1. ソースの開発を行う。Jekyllの使い方に関しては[Jekyllドキュメンテーション](https://jekyllrb.com/docs/home/)を参照
+3. ブラウザで``http://127.0.0.1:4000``を開く
+4. ソースの開発を行う。Jekyllの使い方に関しては[Jekyllドキュメンテーション](https://jekyllrb.com/docs/home/)を参照
 
 ## 注意事項
 


### PR DESCRIPTION
Apparently, nesting multi-line code block breaks the list order. Fixed it.